### PR TITLE
changed version number to 3 digits, 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageResource.js",
-  "version": "1.1",
+  "version": "1.2.0",
   "description": "Javascript library for loading and using message resource property files.",
   "author": {
     "name": "Suhaib Khan",


### PR DESCRIPTION
Npm requires three digits in version, thus npm install failed. I changed to 3 digits and used 1.2.0, 
now it works. Should probably be made a tag with this version too...
Cheers

npm ERR! argv "/Users/foo/.nvm/v0.11.16/bin/node" "/Users/foo/.nvm/v0.11.16/bin/npm" "install" "suhaibkhan/messageResource.js" "--save"
npm ERR! node v0.11.16
npm ERR! npm  v2.3.0

npm ERR! Invalid version: "1.1"
